### PR TITLE
Add manual order planner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*_with_times.json

--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ Use the Node script `tools/xls_to_json.js` to convert production planning Excel 
 3. The script will generate `SM25.json`, `SM27.json` and `SM28.json` in the same directory.
 
 Each JSON file follows the existing structure used by the application.
+
+## Calculate Order Times
+
+The script `tools/calculate_order_times.js` reads one or more order JSON files and appends production times to each order.
+
+### Example
+
+```bash
+node tools/calculate_order_times.js SM25.json SM27.json SM28.json
+```
+
+The script creates `SM25_with_times.json`, `SM27_with_times.json` and `SM28_with_times.json` with additional fields `productionTimeNormal` and `productionTimeSaxning`.
+
+## Manual Planner
+
+Open `planner.html` in a browser to manually plan orders. The page lets you pick orders for a machine and assign them to FM, EM or Natt shift. The planner calculates start and end times using the same production formulas as the machine pages and splits orders across shifts when necessary.

--- a/planner.html
+++ b/planner.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+<meta charset="UTF-8">
+<title>Manuell Planerare</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Manuell Planering</h1>
+  <label>Maskin:
+    <select id="machineSelect">
+      <option value="SM25">SM25</option>
+      <option value="SM27">SM27</option>
+      <option value="SM28" selected>SM28</option>
+    </select>
+  </label>
+  <h2>Tillgängliga ordrar</h2>
+  <div id="orderList"></div>
+  <h2>Planerat schema</h2>
+  <div id="scheduleContainer"></div>
+  <script src="production.js"></script>
+  <script src="planner.js"></script>
+</body>
+</html>

--- a/planner.js
+++ b/planner.js
@@ -1,0 +1,102 @@
+const shiftTimings = {
+  FM: { start: 6 * 60, end: 14 * 60 },
+  EM: { start: 14 * 60, end: 22.5 * 60 },
+  Natt: { start: 22.5 * 60, end: 30 * 60 }
+};
+
+const schedule = {
+  FM: { nextStart: shiftTimings.FM.start, orders: [] },
+  EM: { nextStart: shiftTimings.EM.start, orders: [] },
+  Natt: { nextStart: shiftTimings.Natt.start, orders: [] }
+};
+
+let availableOrders = [];
+
+function nextShift(shift) {
+  return shift === 'FM' ? 'EM' : shift === 'EM' ? 'Natt' : 'FM';
+}
+
+function formatTime(mins) {
+  const h = Math.floor(mins / 60) % 24;
+  const m = Math.round(mins % 60);
+  return String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0');
+}
+
+function renderOrderList() {
+  const list = document.getElementById('orderList');
+  list.innerHTML = '';
+  availableOrders.forEach((o, idx) => {
+    const div = document.createElement('div');
+    div.className = 'order-entry';
+    div.innerHTML = `${o['Kundorder']} - ${o['Planerad Vikt']} kg ` +
+      `<button data-idx="${idx}">Lägg till</button>`;
+    div.querySelector('button').onclick = () => addOrder(idx);
+    list.appendChild(div);
+  });
+}
+
+function renderSchedule() {
+  const container = document.getElementById('scheduleContainer');
+  container.innerHTML = '';
+  Object.keys(schedule).forEach(shift => {
+    const s = schedule[shift];
+    const h = document.createElement('h3');
+    h.textContent = shift + '-skift';
+    container.appendChild(h);
+    const ul = document.createElement('ul');
+    s.orders.forEach(o => {
+      const li = document.createElement('li');
+      li.textContent = `${o.orderId} ${formatTime(o.start)} - ${formatTime(o.end)} (${o.weight.toFixed(1)} kg)`;
+      ul.appendChild(li);
+    });
+    container.appendChild(ul);
+  });
+}
+
+function scheduleOrder(order, shift) {
+  let timeLeft = order.productionTimeNormal;
+  let weightLeft = parseFloat(order['Planerad Vikt']) || 0;
+  const rate = weightLeft / order.productionTimeNormal;
+  while (timeLeft > 0) {
+    if (schedule[shift].nextStart < shiftTimings[shift].start)
+      schedule[shift].nextStart = shiftTimings[shift].start;
+    if (schedule[shift].nextStart >= shiftTimings[shift].end) {
+      shift = nextShift(shift);
+      continue;
+    }
+    const start = schedule[shift].nextStart;
+    const available = shiftTimings[shift].end - start;
+    const runTime = Math.min(timeLeft, available);
+    const weight = rate * runTime;
+    schedule[shift].orders.push({ orderId: order['Kundorder'], start, end: start + runTime, weight });
+    schedule[shift].nextStart = start + runTime;
+    timeLeft -= runTime;
+    weightLeft -= weight;
+    if (timeLeft > 0) shift = nextShift(shift);
+  }
+}
+
+function addOrder(idx) {
+  const order = availableOrders[idx];
+  const shift = prompt('Lägg till i skift (FM/EM/Natt):', 'FM');
+  if (!shiftTimings[shift]) return;
+  scheduleOrder(order, shift);
+  availableOrders.splice(idx, 1);
+  renderOrderList();
+  renderSchedule();
+}
+
+function loadOrders(machine) {
+  fetch(machine + '.json')
+    .then(r => r.json())
+    .then(data => {
+      availableOrders = calculateAllProductionTimes(data);
+      renderOrderList();
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const select = document.getElementById('machineSelect');
+  loadOrders(select.value);
+  select.addEventListener('change', () => loadOrders(select.value));
+});

--- a/style.css
+++ b/style.css
@@ -279,3 +279,7 @@ button:hover, .shift-btn:hover { background: #2563eb; }
 .summary-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;}
 .summary-header .arrow{font-size:1.5em;transition:transform 0.2s;}
 
+
+.order-entry{margin-bottom:4px;}
+.order-entry button{margin-left:8px;}
+

--- a/tools/calculate_order_times.js
+++ b/tools/calculate_order_times.js
@@ -1,0 +1,170 @@
+const fs = require('fs');
+
+// Speed curves identical to production.js
+const machineSpeedCurves = {
+  SM25: [
+    { size: 400, speed: 70 },
+    { size: 500, speed: 100 },
+    { size: 600, speed: 150 },
+    { size: 700, speed: 230 },
+    { size: 750, speed: 300 },
+    { size: 900, speed: 300 },
+    { size: 950, speed: 280 },
+    { size: 1000, speed: 250 },
+    { size: 1100, speed: 225 },
+    { size: 1400, speed: 200 },
+    { size: 1600, speed: 200 }
+  ],
+  SM27: [
+    { size: 400, speed: 30 },
+    { size: 500, speed: 150 },
+    { size: 600, speed: 200 },
+    { size: 700, speed: 270 },
+    { size: 720, speed: 300 },
+    { size: 900, speed: 300 },
+    { size: 1200, speed: 300 },
+    { size: 1800, speed: 300 }
+  ],
+  SM28: [
+    { size: 400, speed: 240 },
+    { size: 450, speed: 270 },
+    { size: 500, speed: 300 },
+    { size: 650, speed: 300 },
+    { size: 700, speed: 280 },
+    { size: 800, speed: 260 },
+    { size: 900, speed: 260 },
+    { size: 1200, speed: 260 },
+    { size: 1800, speed: 260 }
+  ]
+};
+
+function getMachineSpeed(machineId, sheetLength) {
+  const curve = machineSpeedCurves[machineId] || machineSpeedCurves['SM28'];
+  if (!sheetLength || sheetLength < curve[0].size) return curve[0].speed;
+  if (sheetLength >= curve[curve.length - 1].size) return curve[curve.length - 1].speed;
+  for (let i = 0; i < curve.length - 1; i++) {
+    if (sheetLength >= curve[i].size && sheetLength < curve[i + 1].size) {
+      const x0 = curve[i].size, y0 = curve[i].speed;
+      const x1 = curve[i + 1].size, y1 = curve[i + 1].speed;
+      return y0 + (y1 - y0) * (sheetLength - x0) / (x1 - x0);
+    }
+  }
+  return 200;
+}
+
+function estimateRollCount(order) {
+  const reservedWeight = parseFloat(order['Reserverad Vikt'] || '0').toString().replace(/\s/g, '') || 0;
+  const plannedWeight = parseFloat(order['Planerad Vikt'] || '0').toString().replace(/\s/g, '') || 0;
+  const gramvikt = parseFloat(order['Gramvikt']) || 0;
+  const rawRollWidthStr = order['RawRollWidth'] || '';
+  const rawRollWidths = rawRollWidthStr.split(',').map(x => parseFloat(x.trim()) || 0).filter(w => w > 0);
+  const numUniqueWidths = new Set(rawRollWidths).size;
+  const maxRawRollWidth = Math.max(...rawRollWidths, 0);
+  const sheetLength = parseFloat(order['Arklängd']) || 0;
+  const lanes = parseFloat(order['Antal banor']) || 1;
+  const expectedWidth = parseFloat(order['Arkbredd']) || 0;
+
+  const rollsStr = order['Rullar'] || '';
+  const [availableRollsStr, allocatedRollsStr] = rollsStr.split('(').map(s => s.replace(')', ''));
+  const availableRolls = parseInt(availableRollsStr) || 0;
+  const allocatedRolls = parseInt(allocatedRollsStr) || 0;
+
+  let rolls;
+  if (reservedWeight > 0 && allocatedRolls > 0) {
+    rolls = allocatedRolls;
+  } else if (plannedWeight > 0 && (availableRolls > 0 || allocatedRolls > 0)) {
+    const adjustedPlannedWeight = plannedWeight * 1.1;
+    const avgWeightWithAllocated = allocatedRolls > 0 ? adjustedPlannedWeight / allocatedRolls : Infinity;
+    rolls = (avgWeightWithAllocated >= 100 && avgWeightWithAllocated <= 5000 && allocatedRolls > availableRolls) ? allocatedRolls : availableRolls;
+  } else if (plannedWeight > 0) {
+    const adjustedPlannedWeight = plannedWeight * 1.1;
+    if (adjustedPlannedWeight < 2000) {
+      rolls = numUniqueWidths > 0 ? numUniqueWidths : 2;
+      if (numUniqueWidths === 5) rolls = 5;
+    } else {
+      rolls = Math.max(2, numUniqueWidths);
+      if (numUniqueWidths === 5) rolls = 5;
+    }
+  } else {
+    const rollWeightPerMeter = (gramvikt * maxRawRollWidth) / 1000000;
+    const estimatedTotalLength = plannedWeight * 1.1 / rollWeightPerMeter;
+    rolls = Math.ceil(estimatedTotalLength / (sheetLength || 1));
+  }
+
+  const spillFactor = expectedWidth > 0 && maxRawRollWidth > 0 ? Math.max(0.5, 1 - (expectedWidth * lanes) / maxRawRollWidth) : 1;
+  if (spillFactor < 0.5) console.warn('Hög spillfaktor för order', order['Kundorder']);
+
+  return rolls;
+}
+
+function calculateStopTimes(order) {
+  const machineId = order['Maskin id'] || 'SM28';
+  const rawRollWidth = parseFloat(order['RawRollWidth'].split(',')[0]) || 0;
+  const rolls = estimateRollCount(order);
+
+  const normalSetupTime = 15 * 60;
+  const normalStopTime = normalSetupTime + rolls * 90;
+
+  const isSaxningEligible = (machineId === 'SM27' || machineId === 'SM28') && rawRollWidth <= 1035 && rolls >= 2;
+  const saxningSetupTime = 25 * 60;
+  const numSaxningPairs = Math.ceil(rolls / 2);
+  const saxningStopTime = isSaxningEligible ? saxningSetupTime + (numSaxningPairs * 10 * 60) : 0;
+
+  return { normalStopTime, saxningStopTime };
+}
+
+function calculateProductionTime(order) {
+  const machineId = order['Maskin id'] || 'SM28';
+  const sheetLength = parseFloat(order['Arklängd']) || 0;
+  const speed = getMachineSpeed(machineId, sheetLength);
+
+  const planeradVikt = parseFloat((order['Planerad Vikt'] || '0').toString().replace(/\s/g, '')) || 0;
+  const gramvikt = parseFloat(order['Gramvikt']) || 0;
+  const rawRollWidthStr = order['RawRollWidth'] || '';
+  const rawRollWidths = rawRollWidthStr.split(',').map(x => parseFloat(x.trim()) || 0);
+  const maxRawRollWidth = Math.max(...rawRollWidths, 0);
+  const lanes = parseFloat(order['Antal banor']) || 1;
+  const expectedWidth = parseFloat(order['Arkbredd']) || 0;
+
+  if (gramvikt <= 0 || maxRawRollWidth <= 0 || speed <= 0) {
+    console.warn('Ogiltiga värden för order', order['Kundorder']);
+    return { normalTime: 0, saxningTime: 0 };
+  }
+
+  const L = (planeradVikt * 1000000) / (gramvikt * maxRawRollWidth);
+  const spillFactor = expectedWidth > 0 && maxRawRollWidth > 0 ? Math.max(0.5, 1 - (expectedWidth * lanes) / maxRawRollWidth) : 1;
+  const productionTimeMinutes = (L / speed) / spillFactor;
+  const productionTimeSeconds = productionTimeMinutes * 60;
+
+  const { normalStopTime, saxningStopTime } = calculateStopTimes(order);
+
+  const normalTime = (productionTimeSeconds + normalStopTime) / 60;
+  const saxningTime = (productionTimeSeconds + saxningStopTime) / 60;
+
+  return { normalTime, saxningTime };
+}
+
+function calculateAllProductionTimes(orders) {
+  return orders.map(order => {
+    const { normalTime, saxningTime } = calculateProductionTime(order);
+    return { ...order, productionTimeNormal: normalTime, productionTimeSaxning: saxningTime };
+  });
+}
+
+function processFile(inputPath) {
+  const data = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+  const result = calculateAllProductionTimes(data);
+  const outPath = inputPath.replace(/\.json$/i, '_with_times.json');
+  fs.writeFileSync(outPath, JSON.stringify(result, null, 2), 'utf8');
+  console.log(`Wrote ${outPath}`);
+}
+
+if (require.main === module) {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('Usage: node tools/calculate_order_times.js <jsonFile...>');
+    process.exit(1);
+  }
+  files.forEach(processFile);
+}
+


### PR DESCRIPTION
## Summary
- add script to calculate production times and emit new JSON files
- build a simple interactive planner page for manually scheduling orders
- document usage in README
- small style update

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846c715279c832887249350929cd083