### PR TITLE
Add custom order sequencing and creation

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -16,6 +16,10 @@
   </label>
   <h2>Tillgängliga ordrar</h2>
   <div id="orderList"></div>
+  <button id="addCustomBtn">Lägg till egen order</button>
+  <h2>Planerad ordningsföljd</h2>
+  <div id="sequenceList"></div>
+  <button id="generateScheduleBtn">Generera schema</button>
   <h2>Planerat schema</h2>
   <div id="scheduleContainer"></div>
   <script src="production.js"></script>

--- a/style.css
+++ b/style.css
@@ -304,4 +304,6 @@ button:hover, .shift-btn:hover { background: #2563eb; }
 
 .order-entry{margin-bottom:4px;}
 .order-entry button{margin-left:8px;}
+#sequenceList .order-entry button{margin-left:4px;}
+#generateScheduleBtn,#addCustomBtn{margin-top:8px;margin-right:4px;}
 


### PR DESCRIPTION
## Summary
- allow adding custom orders in planner
- support building a planned order sequence
- generate schedule from the planned sequence
- minor styles for new buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846e24915a883289c586964706f6b9b