### PR TITLE
Remove automatic execution from production.js

### DIFF
--- a/production.js
+++ b/production.js
@@ -205,9 +205,14 @@ async function processOrdersFromJson(jsonFile) {
 }
 
 // Exempel på användning
-(async () => {
-    const files = ['SM25.json', 'SM27.json', 'SM28.json'];
-    for (const file of files) {
-        await processOrdersFromJson(file);
-    }
-})();
+// (async () => {
+//     const files = ['SM25.json', 'SM27.json', 'SM28.json'];
+//     for (const file of files) {
+//         await processOrdersFromJson(file);
+//     }
+// })();
+
+// Export for Node.js environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.processOrdersFromJson = processOrdersFromJson;
+}


### PR DESCRIPTION
## Summary
- stop automatic execution of the async loader in `production.js`
- expose `processOrdersFromJson` when running under Node.js

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68471b2a0de4832885b4835d590026c7