### PR TITLE
Modernize UI and enhance planner

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>Planerare</title>
-=======
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>

--- a/planner.js
+++ b/planner.js
@@ -158,15 +158,16 @@ function generateSchedule() {
   renderSchedule();
 }
 
-function addCustomOrder() {
-  const orderId = prompt('Kundorder:');
+function addCustomOrder(e) {
+  if(e) e.preventDefault();
+  const orderId = document.getElementById('coId').value.trim();
   if (!orderId) return;
-  const weight = parseFloat(prompt('Planerad Vikt (kg):', '0')) || 0;
-  const gram = parseFloat(prompt('Gramvikt:', '0')) || 0;
-  const length = parseFloat(prompt('Arklängd (mm):', '0')) || 0;
-  const width = prompt('RawRollWidth (comma separated if flera):', '0');
-  const lanes = parseFloat(prompt('Antal banor:', '1')) || 1;
-  const sheetW = parseFloat(prompt('Arkbredd:', '0')) || 0;
+  const weight = parseFloat(document.getElementById('coWeight').value) || 0;
+  const gram = parseFloat(document.getElementById('coGram').value) || 0;
+  const length = parseFloat(document.getElementById('coLen').value) || 0;
+  const width = document.getElementById('coWidth').value || '';
+  const lanes = parseFloat(document.getElementById('coLanes').value) || 1;
+  const sheetW = parseFloat(document.getElementById('coSheet').value) || 0;
   const machine = document.getElementById('machineSelect').value;
   const order = {
     'Kundorder': orderId,
@@ -183,6 +184,7 @@ function addCustomOrder() {
   order.productionTimeSaxning = saxningTime;
   availableOrders.push(order);
   renderOrderList();
+  if(e) e.target.reset();
 }
 
 function loadOrders(machine) {
@@ -218,7 +220,16 @@ function loadSelectedPlan(){
 document.addEventListener('DOMContentLoaded',()=>{
   const select=document.getElementById('machineSelect');
   loadOrders(select.value);
-  select.addEventListener('change', () => loadOrders(select.value));
-  document.getElementById('addCustomBtn').onclick = addCustomOrder;
+  loadSavedNames(select.value);
+  select.addEventListener('change', () => { loadOrders(select.value); loadSavedNames(select.value); });
+  document.getElementById('savePlanBtn').onclick = () => {
+    const name=document.getElementById('planName').value.trim();
+    if(!name){ alert('Ange namn f\u00f6r planen'); return; }
+    savePlan(select.value,name,plannedSequence);
+    loadSavedNames(select.value);
+    alert('Plan sparad');
+  };
+  document.getElementById('loadPlanBtn').onclick = loadSelectedPlan;
+  document.getElementById('customOrderForm').addEventListener('submit', addCustomOrder);
   document.getElementById('generateScheduleBtn').onclick = generateSchedule;
 });

--- a/production.js
+++ b/production.js
@@ -205,9 +205,14 @@ async function processOrdersFromJson(jsonFile) {
 }
 
 // Exempel på användning
-(async () => {
-    const files = ['SM25.json', 'SM27.json', 'SM28.json'];
-    for (const file of files) {
-        await processOrdersFromJson(file);
-    }
-})();
+// (async () => {
+//     const files = ['SM25.json', 'SM27.json', 'SM28.json'];
+//     for (const file of files) {
+//         await processOrdersFromJson(file);
+//     }
+// })();
+
+// Export for Node.js environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.processOrdersFromJson = processOrdersFromJson;
+}

--- a/style.css
+++ b/style.css
@@ -1,15 +1,15 @@
 /* --- Bas --- */
 body {
-  background: linear-gradient(120deg, #f8fafc 0%, #e0e7ef 100%);
-  color: #222;
+  background: #f3f4f6;
+  color: #374151;
   font-family: 'Inter', 'Roboto', Arial, sans-serif;
 }
 
 /* --- Layout & Containers --- */
 .main-hub, .container {
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 4px 20px #e0e7ef;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.05);
   margin: 20px auto;
   padding: 24px;
   max-width: 1200px;
@@ -208,19 +208,19 @@ body {
 /* --- Buttons --- */
 button, .shift-btn {
   padding: 10px 16px;
-  background: #3b82f6;
+  background: #4f46e5;
   color: #fff;
   border: none;
-  border-radius: 7px;
+  border-radius: 8px;
   cursor: pointer;
   margin-top: 8px;
   transition: background 0.2s;
-  font-weight: 700;
+  font-weight: 600;
   font-size: 1em;
-  box-shadow: 0 2px 8px #1e40af33;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
-button:hover, .shift-btn:hover { background: #2563eb; }
-.shift-btn.active-shift, .shift-btn:focus { background: #2563eb; color: #fff; box-shadow: 0 4px 12px #b6d0fa; }
+button:hover, .shift-btn:hover { background: #4338ca; }
+.shift-btn.active-shift, .shift-btn:focus { background: #4338ca; color: #fff; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
 
 /* --- Shiftval Sidebar --- */
 .shift-sidebar { margin-top: 24px; width: 100%; }
@@ -268,8 +268,8 @@ button:hover, .shift-btn:hover { background: #2563eb; }
 .shift-summary-mini { background:#f1f5fa; border-radius:8px; padding:6px 10px; margin-top:6px; font-size:0.95em; }
 
 .nav-buttons { display:flex; justify-content:center; gap:20px; margin-top:20px; flex-wrap:wrap; }
-.nav-button { background:#2563eb; color:#fff; padding:12px 18px; text-decoration:none; border-radius:8px; box-shadow:0 2px 8px #b6d0fa; font-weight:600; transition:background .2s; }
-.nav-button:hover { background:#1e40af; }
+.nav-button { background:#4f46e5; color:#fff; padding:12px 18px; text-decoration:none; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.1); font-weight:600; transition:background .2s; }
+.nav-button:hover { background:#4338ca; }
 
 /* Extra info text */
 .guidance {
@@ -289,9 +289,20 @@ button:hover, .shift-btn:hover { background: #2563eb; }
 .shift-toggle .shift-arrow { font-size:1.2em; margin-right:8px; transition:transform 0.2s; }
 .shift-toggle.active-shift .shift-arrow { transform:rotate(90deg); }
 .shift-toggle::after { content:'Klicka för att visa'; display:block; font-size:0.85em; color:#2563eb; margin-top:2px; font-weight:400; letter-spacing:0; }
-.shift-wrapper { background:#f4f7fb; border-radius:0 0 12px 12px; box-shadow:0 2px 12px #e0e7ef; margin-bottom:32px; padding:24px; }
+.shift-wrapper { background:#f4f7fb; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.05); margin-bottom:32px; padding:24px; }
 .shift-summary { background:#e0e7ef; border-radius:8px; margin:0 0 18px 0; padding:16px 20px; font-size:1.08em; }
 .orders-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); gap:18px; margin-top:18px; }
+.orders-list { display:flex; flex-direction:column; gap:10px; margin-top:18px; }
+.order-row {
+  background:#fff;
+  border:1px solid #e5e7eb;
+  border-radius:8px;
+  padding:10px;
+  box-shadow:0 2px 4px rgba(0,0,0,0.05);
+}
+.order-summary{display:flex;align-items:center;justify-content:space-between;cursor:pointer;gap:10px;}
+.calc-result{margin-top:6px;background:#f9fafb;border-radius:6px;padding:8px;}
+.analysis-box{background:#fef2f2;border-left:4px solid #ef4444;padding:10px 12px;border-radius:8px;color:#991b1b;margin-bottom:12px;}
 @media (max-width:700px){
   .shift-bar { flex-direction: column; gap:10px; }
   .shift-wrapper { padding:10px 4px; }
@@ -306,3 +317,9 @@ button:hover, .shift-btn:hover { background: #2563eb; }
 .order-entry button{margin-left:8px;}
 #sequenceList .order-entry button{margin-left:4px;}
 #generateScheduleBtn,#addCustomBtn{margin-top:8px;margin-right:4px;}
+
+input, select {
+  border:1px solid #d1d5db;
+  border-radius:6px;
+  padding:6px 8px;
+}


### PR DESCRIPTION
## Summary
- revamp styles with softer colors and rounded edges
- list shift orders in rows and show issues per shift
- fix planner HTML merge marker
- enable saving and loading plans via UI
- support adding orders via the form

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68471b2a0de4832885b4835d590026c7