### PR TITLE
Fix load plan dropdown

### DIFF
--- a/planner.js
+++ b/planner.js
@@ -186,7 +186,7 @@ function addCustomOrder() {
 }
 
 function loadOrders(machine) {
-  fetch(machine + '.json')
+  return fetch(machine + '.json')
     .then(r => r.json())
     .then(data => {
       availableOrders = calculateAllProductionTimes(data);
@@ -205,6 +205,7 @@ function loadSelectedPlan(){
   const plan=getSaved(machine)[name];
   if(!plan) return;
   loadOrders(machine).then(()=>{
+    document.getElementById('savedPlans').value = name;
     plan.forEach(p=>{
       const idx=availableOrders.findIndex(o=>o['Kundorder']===p['Kundorder']);
       if(idx>-1) availableOrders.splice(idx,1);


### PR DESCRIPTION
## Summary
- return `fetch()` promise in `loadOrders`
- preserve dropdown selection in `loadSelectedPlan`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68471b29840c8328a42f0f6de1aa3e5b