### PR TITLE
Improve machine navigation sidebar

### DIFF
--- a/SM25.html
+++ b/SM25.html
@@ -14,19 +14,19 @@
             <nav>
                 <a href="index.html" class="sidebar-link">&#8592; Tillbaka till översikt</a>
             </nav>
-            <div class="shift-sidebar">
-                <h2>Välj skift</h2>
-                <div class="shift-list">
-                    <button class="shift-btn sm25-shift-btn" data-shift="FM">FM-Skift</button>
-                    <button class="shift-btn sm25-shift-btn" data-shift="EM">EM-Skift</button>
-                    <button class="shift-btn sm25-shift-btn" data-shift="Natt">Natt-Skift</button>
+            <div class="machine-sidebar">
+                <h2>Välj maskin</h2>
+                <div class="machine-list">
+                    <a href="SM25.html" class="sidebar-link machine-link active">SM25</a>
+                    <a href="SM27.html" class="sidebar-link machine-link">SM27</a>
+                    <a href="SM28.html" class="sidebar-link machine-link">SM28</a>
                 </div>
             </div>
         </aside>
         <main class="sm25-main">
             <header class="sm25-header">
                 <h1>SM25 Produktionsplan</h1>
-                <p class="sm25-sub">Planering och uträkning för dagens produktion. Välj skift i sidomenyn.</p>
+                <p class="sm25-sub">Planering och uträkning för dagens produktion. Välj skift i skiftbaren ovan.</p>
             </header>
             <div id="shiftBarContainer"></div>
             <div id="ordersContainer"></div>

--- a/SM27.html
+++ b/SM27.html
@@ -14,19 +14,19 @@
             <nav>
                 <a href="index.html" class="sidebar-link">&#8592; Tillbaka till översikt</a>
             </nav>
-            <div class="shift-sidebar">
-                <h2>Välj skift</h2>
-                <div class="shift-list">
-                    <button class="shift-btn sm25-shift-btn" data-shift="FM">FM-Skift</button>
-                    <button class="shift-btn sm25-shift-btn" data-shift="EM">EM-Skift</button>
-                    <button class="shift-btn sm25-shift-btn" data-shift="Natt">Natt-Skift</button>
+            <div class="machine-sidebar">
+                <h2>Välj maskin</h2>
+                <div class="machine-list">
+                    <a href="SM25.html" class="sidebar-link machine-link">SM25</a>
+                    <a href="SM27.html" class="sidebar-link machine-link active">SM27</a>
+                    <a href="SM28.html" class="sidebar-link machine-link">SM28</a>
                 </div>
             </div>
         </aside>
         <main class="sm25-main">
             <header class="sm25-header">
                 <h1>SM27 Produktionsplan</h1>
-                <p class="sm25-sub">Planering och uträkning för dagens produktion. Välj skift i sidomenyn.</p>
+                <p class="sm25-sub">Planering och uträkning för dagens produktion. Välj skift i skiftbaren ovan.</p>
             </header>
             <div id="shiftBarContainer"></div>
             <div id="ordersContainer"></div>

--- a/SM28.html
+++ b/SM28.html
@@ -14,19 +14,19 @@
             <nav>
                 <a href="index.html" class="sidebar-link">&#8592; Tillbaka till översikt</a>
             </nav>
-            <div class="shift-sidebar">
-                <h2>Välj skift</h2>
-                <div class="shift-list">
-                    <button class="shift-btn sm25-shift-btn" data-shift="FM">FM-Skift</button>
-                    <button class="shift-btn sm25-shift-btn" data-shift="EM">EM-Skift</button>
-                    <button class="shift-btn sm25-shift-btn" data-shift="Natt">Natt-Skift</button>
+            <div class="machine-sidebar">
+                <h2>Välj maskin</h2>
+                <div class="machine-list">
+                    <a href="SM25.html" class="sidebar-link machine-link">SM25</a>
+                    <a href="SM27.html" class="sidebar-link machine-link">SM27</a>
+                    <a href="SM28.html" class="sidebar-link machine-link active">SM28</a>
                 </div>
             </div>
         </aside>
         <main class="sm25-main">
             <header class="sm25-header">
                 <h1>SM28 Produktionsplan</h1>
-                <p class="sm25-sub">Planering och uträkning för dagens produktion. Välj skift i sidomenyn.</p>
+                <p class="sm25-sub">Planering och uträkning för dagens produktion. Välj skift i skiftbaren ovan.</p>
             </header>
             <div id="shiftBarContainer"></div>
             <div id="ordersContainer"></div>

--- a/style.css
+++ b/style.css
@@ -232,6 +232,14 @@ button:hover, .shift-btn:hover { background: #2563eb; }
   gap: 8px;
 }
 
+/* --- Maskinval Sidebar --- */
+.machine-sidebar { margin-top: 24px; width: 100%; }
+.machine-sidebar h2 { font-size: 1em; color: #a5b4fc; margin-bottom: 8px; margin-top: 0; }
+.machine-list { display: flex; flex-direction: column; gap: 8px; }
+.machine-link { background: #3b82f6; color: #fff; padding: 8px 12px; border-radius: 7px; text-decoration: none; text-align: center; font-weight: 700; box-shadow: 0 2px 8px #1e40af33; }
+.machine-link:hover { background: #2563eb; }
+.machine-link.active { background: #1e40af; }
+
 /* --- Index summary and navigation --- */
 .summary-container { text-align: center; margin-top: 20px; }
 .summary-box { margin-top:20px; }


### PR DESCRIPTION
## Summary
- allow selecting machine from sidebar on machine pages
- adjust machine page subtitle
- style sidebar machine selector

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846c678fb14832888cf38bb03d83197