### PR TITLE
Fix planner scrolling and order sorting

### DIFF
--- a/planner.js
+++ b/planner.js
@@ -206,41 +206,54 @@ function addCustomOrder(e) {
   generateSchedule();
 }
 
-function loadOrders(machine) {
-  return fetch(machine + '.json')
-    .then(r => r.json())
-    .then(data => {
-      availableOrders = calculateAllProductionTimes(data);
-      plannedSequence = [];
-      resetSchedule();
-      renderOrderList();
-      renderSequence();
-      generateSchedule();
-    });
+async function loadOrders(machine) {
+  try {
+    const resp = await fetch(machine + '.json');
+    const data = await resp.json();
+    availableOrders = calculateAllProductionTimes(data)
+      .sort((a,b)=>{
+        const aStart=parseFloat(a['Planerad start']||0);
+        const bStart=parseFloat(b['Planerad start']||0);
+        return aStart-bStart;
+      });
+  } catch (err) {
+    console.error('Could not load orders:', err);
+    availableOrders = [];
+  }
+  plannedSequence = [];
+  resetSchedule();
+  renderOrderList();
+  renderSequence();
+  generateSchedule();
 }
 
-function loadSelectedPlan(){
+async function loadSelectedPlan(){
   const sel=document.getElementById('savedPlans');
-  const name=sel.value; if(!name) {plannedSequence=[];renderSequence();renderOrderList();return;}
+  const name=sel.value;
+  if(!name){
+    plannedSequence=[];
+    renderSequence();
+    renderOrderList();
+    return;
+  }
   const machine=document.getElementById('machineSelect').value;
   const plan=getSaved(machine)[name];
   if(!plan) return;
-  loadOrders(machine).then(()=>{
-    document.getElementById('savedPlans').value = name;
-    plan.forEach(p=>{
-      const idx=availableOrders.findIndex(o=>o['Kundorder']===p['Kundorder']);
-      if(idx>-1) availableOrders.splice(idx,1);
-    });
-    plannedSequence=plan.slice();
-    renderOrderList();
-    renderSequence();
-    generateSchedule();
+  await loadOrders(machine);
+  document.getElementById('savedPlans').value = name;
+  plan.forEach(p=>{
+    const idx=availableOrders.findIndex(o=>o['Kundorder']===p['Kundorder']);
+    if(idx>-1) availableOrders.splice(idx,1);
   });
+  plannedSequence=plan.slice();
+  renderOrderList();
+  renderSequence();
+  generateSchedule();
 }
 
-document.addEventListener('DOMContentLoaded',()=>{
+document.addEventListener('DOMContentLoaded',async ()=>{
   const select=document.getElementById('machineSelect');
-  loadOrders(select.value);
+  await loadOrders(select.value);
   loadSavedNames(select.value);
   select.addEventListener('change', () => { loadOrders(select.value); loadSavedNames(select.value); });
   document.getElementById('savePlanBtn').onclick = () => {

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
 html, body {
   height: 100%;
   margin: 0;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 /* --- Layout & Containers --- */
@@ -364,7 +364,7 @@ input, select {
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
 }
 .planner-header {
   display: flex;
@@ -382,7 +382,7 @@ input, select {
   display: flex;
   flex: 1;
   gap: 20px;
-  overflow: hidden;
+  overflow: visible;
 }
 .planner-left, .planner-right {
   flex: 1;


### PR DESCRIPTION
## Summary
- sort orders by planned start when loading JSON files
- allow vertical scrolling on planner page

## Testing
- `npm test`
- `npx eslint .` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6847305223988328affcce4eb06d5903