### PR TITLE
Compact available orders list

### DIFF
--- a/planner.js
+++ b/planner.js
@@ -47,14 +47,22 @@ function loadSavedNames(machine){
   });
 }
 
+function formatDuration(mins){
+  const h=Math.floor(mins/60);const m=Math.round(mins%60);
+  return h>0?`${h}h ${m}m`:`${m}m`;
+}
+
 function renderOrderList() {
   const list = document.getElementById('orderList');
   list.innerHTML = '';
   availableOrders.forEach((o, idx) => {
     const div = document.createElement('div');
     div.className = 'order-entry';
-    div.innerHTML = `${o['Kundorder']} - ${o['Planerad Vikt']} kg ` +
-      `<button data-idx="${idx}">Lägg till ordning</button>`;
+    div.innerHTML = `
+      <span class="order-id">${o['Kundorder']}</span>
+      <span class="weight">${(o['Planerad Vikt'] || 0).toFixed(1)} kg</span>
+      <span class="duration">${formatDuration(o.productionTimeNormal)}</span>
+      <button data-idx="${idx}" class="small-btn icon-btn">+</button>`;
     div.querySelector('button').onclick = () => addToSequence(idx);
     list.appendChild(div);
   });
@@ -68,9 +76,9 @@ function renderSequence() {
     div.className = 'order-entry';
     div.draggable = true;
     div.innerHTML = `${idx + 1}. ${o['Kundorder']} - ${o['Planerad Vikt']} kg ` +
-      `<button data-idx="${idx}" class="up">&#8679;</button>` +
-      `<button data-idx="${idx}" class="down">&#8681;</button>` +
-      `<button data-idx="${idx}" class="remove">X</button>`;
+      `<button data-idx="${idx}" class="small-btn icon-btn up">&#8679;</button>` +
+      `<button data-idx="${idx}" class="small-btn icon-btn down">&#8681;</button>` +
+      `<button data-idx="${idx}" class="small-btn icon-btn remove">X</button>`;
     div.querySelector('.up').onclick = () => moveSequence(idx, -1);
     div.querySelector('.down').onclick = () => moveSequence(idx, 1);
     div.querySelector('.remove').onclick = () => removeFromSequence(idx);

--- a/style.css
+++ b/style.css
@@ -150,7 +150,7 @@ html, body {
   gap: 6px;
 }
 .order-card-header { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
-.order-icon { font-size: 1.3em; color: #2563eb; }
+.order-icon { font-size: 1.1em; color: #2563eb; }
 .order-card-row { display: flex; justify-content: space-between; font-size: 1em; }
 .order-label { color: #2563eb; font-weight: 600; margin-right: 6px; }
 
@@ -192,8 +192,8 @@ html, body {
   color: #2563eb;
 }
 .calc-step-arrow, .calc-step-arrow-big {
-  font-size: 1.2em;
-  margin-left: 8px;
+  font-size: 1em;
+  margin-left: 6px;
   transition: transform 0.2s;
 }
 .calc-step-content, .calc-step-content-big {
@@ -232,6 +232,15 @@ button, .shift-btn {
 }
 button:hover, .shift-btn:hover { background: #4338ca; }
 .shift-btn.active-shift, .shift-btn:focus { background: #4338ca; color: #fff; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+.small-btn{
+  padding:6px 10px;
+  font-size:0.9em;
+  margin-top:0;
+}
+.icon-btn{
+  padding:4px 6px;
+  font-size:0.8em;
+}
 
 /* --- Shiftval Sidebar --- */
 .shift-sidebar { margin-top: 24px; width: 100%; }
@@ -297,7 +306,7 @@ button:hover, .shift-btn:hover { background: #4338ca; }
 /* --- Machine page elements --- */
 .shift-bar { display:flex; justify-content:center; gap:24px; margin:32px 0 16px 0; }
 .shift-toggle { position:relative; font-weight:600; letter-spacing:0.5px; box-shadow:0 2px 8px #e0e7ef, 0 0 0 2px #3b82f6 inset; }
-.shift-toggle .shift-arrow { font-size:1.2em; margin-right:8px; transition:transform 0.2s; }
+.shift-toggle .shift-arrow { font-size:1em; margin-right:6px; transition:transform 0.2s; }
 .shift-toggle.active-shift .shift-arrow { transform:rotate(90deg); }
 .shift-toggle::after { content:'Klicka för att visa'; display:block; font-size:0.85em; color:#2563eb; margin-top:2px; font-weight:400; letter-spacing:0; }
 .shift-wrapper { background:#f4f7fb; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.05); margin-bottom:32px; padding:24px; }
@@ -325,12 +334,36 @@ button:hover, .shift-btn:hover { background: #4338ca; }
 }
 
 .summary-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;}
-.summary-header .arrow{font-size:1.5em;transition:transform 0.2s;}
+.summary-header .arrow{font-size:1.2em;transition:transform 0.2s;}
 
 
-.order-entry{margin-bottom:4px;}
-.order-entry button{margin-left:8px;}
 #sequenceList .order-entry button{margin-left:4px;}
+#orderList .order-entry button{margin-left:8px;}
+#orderList .order-entry{
+  display:grid;
+  grid-template-columns:1fr 70px 70px auto;
+  align-items:center;
+}
+.order-entry{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  background:#fff;
+  border:1px solid #e5e7eb;
+  border-radius:6px;
+  padding:6px 8px;
+  font-size:0.9em;
+  gap:6px;
+  margin-bottom:4px;
+  box-shadow:0 1px 2px rgba(0,0,0,0.05);
+}
+#orderList .order-entry .weight,#orderList .order-entry .duration{
+  width:70px;
+  text-align:right;
+}
+#orderList{
+  gap:4px;
+}
 #generateScheduleBtn,#addCustomBtn{margin-top:8px;margin-right:4px;}
 
 input, select {


### PR DESCRIPTION
## Summary
- make the order controls smaller and align weight text in a grid
- show estimated duration for each available order
- decrease icon sizes across planner styles

## Testing
- `npm test` *(fails: jest not found)*
- `npx eslint .` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68472c4f4fcc8328962b313ee1ced778