### PR TITLE
Improve planner spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *_with_times.json
+node_modules/

--- a/style.css
+++ b/style.css
@@ -337,8 +337,8 @@ button:hover, .shift-btn:hover { background: #4338ca; }
 .summary-header .arrow{font-size:1.2em;transition:transform 0.2s;}
 
 
-#sequenceList .order-entry button{margin-left:4px;}
-#orderList .order-entry button{margin-left:8px;}
+#sequenceList .order-entry button{margin-left:2px;}
+#orderList .order-entry button{margin-left:4px;}
 #orderList .order-entry{
   display:grid;
   grid-template-columns:1fr 70px 70px auto;
@@ -355,9 +355,13 @@ button:hover, .shift-btn:hover { background: #4338ca; }
   border-radius:6px;
   padding:6px 8px;
   font-size:0.9em;
-  gap:6px;
+  gap:4px;
   margin-bottom:4px;
   box-shadow:0 1px 2px rgba(0,0,0,0.05);
+}
+
+.order-entry span{
+  padding:2px 4px;
 }
 
 #orderList .order-entry .weight,#orderList .order-entry .duration{


### PR DESCRIPTION
## Summary
- reduce gap in order entries and tweak button spacing
- add padding around order text
- ignore node_modules to avoid accidental commits

## Testing
- `CI=true npx jest --runInBand`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68475344fb9c8328b26bea227daf96b3