### PR TITLE
Enable drag-and-drop reordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,23 +9,25 @@
 </head>
 <body>
     <div class="main-hub">
-        <header>
+        <header class="main-header">
             <h1>Produktionsöversikt - 24-timmars cykel</h1>
             <p>Välkommen till översikten för produktionsplaneringen över 24 timmar för arkmaskinerna SM25, SM27 och SM28. Här ser du en summering av varje maskins prestanda per skift. Klicka på en maskin för detaljerad planering och uträkningar.</p>
         </header>
-        <div class="summary-container">
-            <h2>Summering av arkmaskiner</h2>
-            <div class="summary-box" id="machineSummaries"></div>
-        </div>
-        <div class="nav-buttons">
-            <a href="SM25.html" class="nav-button">Gå till SM25</a>
-            <a href="SM27.html" class="nav-button">Gå till SM27</a>
-            <a href="SM28.html" class="nav-button">Gå till SM28</a>
-            <a href="planner.html" class="nav-button">Planerare</a>
-        </div>
-        <div class="guidance">
+        <main class="main-content">
+            <section class="summary-container">
+                <h2>Summering av arkmaskiner</h2>
+                <div class="summary-box" id="machineSummaries"></div>
+            </section>
+            <nav class="nav-buttons">
+                <a href="SM25.html" class="nav-button">Gå till SM25</a>
+                <a href="SM27.html" class="nav-button">Gå till SM27</a>
+                <a href="SM28.html" class="nav-button">Gå till SM28</a>
+                <a href="planner.html" class="nav-button">Planerare</a>
+            </nav>
+        </main>
+        <footer class="guidance">
             <p><strong>Övrigt att tänka på:</strong> Tider baseras på "Arklängd" och "RawRollWidth". Utforska maskinsidor för detaljer.</p>
-        </div>
+        </footer>
     </div>
     <script src="production.js"></script>
     <script>

--- a/machine.js
+++ b/machine.js
@@ -4,6 +4,8 @@
   let isPaused = false;
   let pauseStartTime = 0;
   let totalPauseTime = 0;
+  let currentShifts = { FM: [], EM: [], Natt: [] };
+  let manualStops = [];
 
   function getSavedPlans(){
     const data = JSON.parse(localStorage.getItem("savedPlans")||"{}");
@@ -74,76 +76,9 @@
       if (usedMinutes >= 24 * 60) break;
     }
 
-    const shiftNames = { FM: "FM-Skift", EM: "EM-Skift", Natt: "Natt-Skift" };
-
-    function analyzeShiftOrders(list){
-      const issues = [];
-      const weights = list.map(o=>parseFloat(o["Planerad Vikt"]||0));
-      const smallOrders = weights.filter(w=>w && w<1000).length;
-      if(list.length>8) issues.push("Många ordrar kan ge långa omställningar");
-      if(smallOrders>list.length/2) issues.push("Hög andel små ordrar (<1 ton)");
-      const lengths = new Set(list.map(o=>parseFloat(o["Arklängd"])||0));
-      if(lengths.size>3) issues.push("Stor variation i arklängd");
-      return issues;
-    }
-    Object.keys(shifts).forEach(shift => {
-      const btn = document.createElement("button");
-      btn.className = "shift-toggle";
-      btn.innerHTML = `<span class="shift-arrow">&#9654;</span> ${shiftNames[shift]}`;
-      btn.dataset.shift = shift;
-      btn.addEventListener("click", () => toggleShift(shift));
-      ordersContainer.appendChild(btn);
-
-      const shiftSummary = document.createElement("div");
-      shiftSummary.className = "shift-summary";
-      const totalKg = shifts[shift].reduce((acc,o)=>acc+parseFloat(o["Planerad Vikt"]||0),0);
-      const totalOrders = shifts[shift].length;
-      const totalTime = shifts[shift].reduce((acc,o)=>acc+o.adjustedTime,0);
-      const kgPerHour = totalTime>0 ? (totalKg/(totalTime/60)) : 0;
-      shiftSummary.innerHTML = `
-        <h3>Summering för ${shiftNames[shift]}:</h3>
-        <p>Planerad produktion: ${totalKg.toFixed(2)} kg</p>
-        <p>Körda ordrar: ${totalOrders}</p>
-        <p>Summa KG/TIM: ${kgPerHour.toFixed(2)}</p>`;
-      ordersContainer.appendChild(shiftSummary);
-
-      const shiftDiv = document.createElement("div");
-      shiftDiv.className = "shift-section shift-wrapper";
-      shiftDiv.id = "section-" + shift;
-      shiftDiv.style.display = "none";
-
-      const analysis = analyzeShiftOrders(shifts[shift]);
-      if(analysis.length){
-        const aBox=document.createElement("div");
-        aBox.className="analysis-box";
-        aBox.innerHTML="<b>Analys:</b><ul>"+analysis.map(t=>`<li>${t}</li>`).join("")+"</ul>";
-        shiftDiv.appendChild(aBox);
-      }
-
-      const ordersList = document.createElement("div");
-      ordersList.className = "orders-list";
-      shifts[shift].forEach(order => {
-        const orderDiv = document.createElement("div");
-        orderDiv.className = "order-row";
-        orderDiv.innerHTML = `
-          <div class="order-summary">
-            <span>${order["Kundorder"] || "Okänd"}</span>
-            <span>${(order["Planerad Vikt"] || 0).toFixed(1)} kg</span>
-            <span>${order["Arklängd"] || "?"} mm</span>
-            <span>${order.speed.toFixed(0)} m/min</span>
-            <span>${formatTime(order.startTime)} - ${formatTime(order.endTime)}</span>
-          </div>
-          <div class="calc-result" style="display:none;"></div>`;
-        orderDiv.querySelector(".order-summary").addEventListener("click", function(){
-          showOrderCalculation(this, order, machineId);
-        });
-        ordersList.appendChild(orderDiv);
-      });
-      shiftDiv.appendChild(ordersList);
-      ordersContainer.appendChild(shiftDiv);
-    });
-
-    renderShiftBar(shifts);
+    currentShifts = shifts;
+    recalcSchedule();
+    renderPage();
   }
 
   function toggleShift(shift) {
@@ -165,13 +100,19 @@
   }
 
   function addManualStop(){
-    const mins = parseFloat(prompt("Ange stopp i minuter:",""));
-    if(!isNaN(mins) && mins>0){
-      totalPauseTime += mins;
-      const info=document.getElementById("stopInfo");
-      if(info) info.textContent = `Manuellt stopp på ${mins} min inlagt.`;
-      loadOrders();
+    const from=prompt("Från klockan (HH:MM)","06:00");
+    if(!from) return;
+    const to=prompt("Till klockan (HH:MM)","06:10");
+    if(!to) return;
+    const start=parseTime(from);
+    const end=parseTime(to);
+    if(isNaN(start)||isNaN(end)||end<=start){
+      alert("Ogiltig tid");
+      return;
     }
+    manualStops.push({start,end});
+    recalcSchedule();
+    renderPage();
   }
 
   function formatTime(minutes){
@@ -241,6 +182,119 @@
         e.stopPropagation();
       });
     });
+  }
+
+  function parseTime(str){
+    const [h,m] = str.split(":").map(n=>parseInt(n,10));
+    if(isNaN(h) || isNaN(m)) return NaN;
+    return h*60 + m;
+  }
+
+  function analyzeShiftOrders(list){
+    const issues=[];
+    const weights=list.map(o=>parseFloat(o["Planerad Vikt"]||0));
+    const small=weights.filter(w=>w && w<1000).length;
+    if(list.length>8) issues.push("Många ordrar kan ge långa omställningar");
+    if(small>list.length/2) issues.push("Hög andel små ordrar (<1 ton)");
+    const lengths=new Set(list.map(o=>parseFloat(o["Arklängd"])||0));
+    if(lengths.size>3) issues.push("Stor variation i arklängd");
+    return issues;
+  }
+
+  function recalcSchedule(){
+    const starts={FM:6*60,EM:14*60,Natt:22.5*60};
+    ["FM","EM","Natt"].forEach(s=>{
+      let current=starts[s];
+      currentShifts[s].forEach(o=>{
+        let start=current;
+        let end=start+o.productionTime;
+        manualStops.forEach(st=>{
+          if(st.end<=start||st.start>=end) return;
+          if(st.start<=start){ start=st.end; end=start+o.productionTime; }
+          else if(st.start<end){ end+=st.end-st.start; }
+        });
+        o.startTime=start%1440;
+        o.endTime=end%1440;
+        current=end;
+      });
+    });
+  }
+
+  function renderPage(){
+    const ordersContainer=document.getElementById("ordersContainer");
+    ordersContainer.innerHTML="";
+    const shiftNames={FM:"FM-Skift",EM:"EM-Skift",Natt:"Natt-Skift"};
+    Object.keys(currentShifts).forEach(shift=>{
+      const btn=document.createElement("button");
+      btn.className="shift-toggle";
+      btn.innerHTML=`<span class="shift-arrow">&#9654;</span> ${shiftNames[shift]}`;
+      btn.dataset.shift=shift;
+      btn.addEventListener("click",()=>toggleShift(shift));
+      ordersContainer.appendChild(btn);
+
+      const summary=document.createElement("div");
+      summary.className="shift-summary";
+      const totalKg=currentShifts[shift].reduce((a,o)=>a+parseFloat(o["Planerad Vikt"]||0),0);
+      const totalOrders=currentShifts[shift].length;
+      const totalTime=currentShifts[shift].reduce((a,o)=>a+o.productionTime,0);
+      const kgPerHour=totalTime>0?(totalKg/(totalTime/60)):0;
+      summary.innerHTML=`<h3>Summering för ${shiftNames[shift]}:</h3><p>Planerad produktion: ${totalKg.toFixed(2)} kg</p><p>Körda ordrar: ${totalOrders}</p><p>Summa KG/TIM: ${kgPerHour.toFixed(2)}</p>`;
+      ordersContainer.appendChild(summary);
+
+      const section=document.createElement("div");
+      section.className="shift-section shift-wrapper";
+      section.id="section-"+shift;
+      section.style.display="none";
+
+      const analysis=analyzeShiftOrders(currentShifts[shift]);
+      if(analysis.length){
+        const a=document.createElement("div");
+        a.className="analysis-box";
+        a.innerHTML="<b>Analys:</b><ul>"+analysis.map(t=>`<li>${t}</li>`).join("")+"</ul>";
+        section.appendChild(a);
+      }
+
+      const list=document.createElement("div");
+      list.className="orders-list";
+      list.dataset.shift=shift;
+      list.addEventListener("dragover",e=>e.preventDefault());
+      list.addEventListener("drop",e=>{
+        e.preventDefault();
+        const fromShift=e.dataTransfer.getData("shift");
+        const fromIdx=parseInt(e.dataTransfer.getData("index"),10);
+        if(!fromShift) return;
+        const item=currentShifts[fromShift].splice(fromIdx,1)[0];
+        currentShifts[shift].push(item);
+        recalcSchedule();
+        renderPage();
+      });
+
+      currentShifts[shift].forEach((o,idx)=>{
+        const d=document.createElement("div");
+        d.className="order-row";
+        d.draggable=true;
+        d.addEventListener("dragstart",ev=>{
+          ev.dataTransfer.setData("shift",shift);
+          ev.dataTransfer.setData("index",idx);
+        });
+        d.innerHTML=`<div class="order-summary"><span>${o["Kundorder"]||"Okänd"}</span><span>${(o["Planerad Vikt"]||0).toFixed(1)} kg</span><span>${o["Arklängd"]||"?"} mm</span><span>${o.speed.toFixed(0)} m/min</span><span>${formatTime(o.startTime)} - ${formatTime(o.endTime)}</span></div><div class="calc-result" style="display:none;"></div>`;
+        d.querySelector(".order-summary").addEventListener("click",function(){showOrderCalculation(this,o,machineId);});
+        list.appendChild(d);
+        manualStops.forEach((st,si)=>{
+          if(st.start>=o.startTime && st.start<o.endTime){
+            const sdiv=document.createElement("div");
+            sdiv.className="manual-stop";
+            sdiv.innerHTML=`Stopp ${formatTime(st.start)}-${formatTime(st.end)} <button data-i='${si}'>X</button>`;
+            sdiv.querySelector("button").onclick=()=>{manualStops.splice(si,1);recalcSchedule();renderPage();};
+            list.appendChild(sdiv);
+          }
+        });
+      });
+      section.appendChild(list);
+      ordersContainer.appendChild(section);
+    });
+
+    renderShiftBar(currentShifts);
   }
 
   function renderShiftBar(shifts){

--- a/style.css
+++ b/style.css
@@ -1,8 +1,23 @@
 /* --- Bas --- */
+:root {
+  --primary: #4f46e5;
+  --secondary: #2563eb;
+  --bg: #f3f4f6;
+  --text: #374151;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  background: #f3f4f6;
-  color: #374151;
+  background: var(--bg);
+  color: var(--text);
   font-family: 'Inter', 'Roboto', Arial, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
 }
 html, body {
   height: 100%;
@@ -15,9 +30,10 @@ html, body {
   background: #ffffff;
   border-radius: 16px;
   box-shadow: 0 2px 12px rgba(0,0,0,0.05);
-  margin: 20px auto;
+  margin: 0;
   padding: 24px;
-  max-width: 1200px;
+  max-width: none;
+  width: 100%;
   height: 100%;
   overflow: auto;
 }
@@ -30,7 +46,7 @@ html, body {
 }
 .sm25-sidebar {
   width: 240px;
-  background: #2563eb;
+  background: var(--secondary);
   color: #fff;
   display: flex;
   flex-direction: column;
@@ -58,7 +74,7 @@ html, body {
 
 .sm25-machine-info {
   margin-top: 24px;
-  background: #2563eb;
+  background: var(--secondary);
   border-radius: 8px;
   padding: 10px 14px;
   font-size: 1em;
@@ -83,7 +99,7 @@ html, body {
   padding: 24px 18px 12px 18px;
   margin-bottom: 0;
 }
-.sm25-header h1 { color: #2563eb; font-size: 1.7em; margin: 0 0 8px 0; }
+.sm25-header h1 { color: var(--secondary); font-size: 1.7em; margin: 0 0 8px 0; }
 .sm25-sub { color: #234; font-size: 1em; margin: 0; }
 
 /* --- Shift Bar --- */
@@ -150,9 +166,9 @@ html, body {
   gap: 6px;
 }
 .order-card-header { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
-.order-icon { font-size: 1.1em; color: #2563eb; }
+.order-icon { font-size: 1.1em; color: var(--secondary); }
 .order-card-row { display: flex; justify-content: space-between; font-size: 1em; }
-.order-label { color: #2563eb; font-weight: 600; margin-right: 6px; }
+.order-label { color: var(--secondary); font-weight: 600; margin-right: 6px; }
 
 /* --- Steg-för-steg-kort --- */
 .calc-steps, .calc-steps-horizontal {
@@ -183,13 +199,13 @@ html, body {
   align-items: center;
   justify-content: space-between;
   font-size: 1em;
-  color: #2563eb;
+  color: var(--secondary);
   margin-bottom: 6px;
 }
 .calc-step-title {
   font-size: 1em;
   font-weight: 700;
-  color: #2563eb;
+  color: var(--secondary);
 }
 .calc-step-arrow, .calc-step-arrow-big {
   font-size: 1em;
@@ -219,7 +235,7 @@ html, body {
 /* --- Buttons --- */
 button, .shift-btn {
   padding: 10px 16px;
-  background: #4f46e5;
+  background: var(--primary);
   color: #fff;
   border: none;
   border-radius: 8px;
@@ -272,24 +288,46 @@ button:hover, .shift-btn:hover { background: #4338ca; }
   box-shadow: 0 2px 8px #1e40af33;
   transition: background 0.2s;
 }
-.machine-btn:hover { background: #2563eb; }
+.machine-btn:hover { background: var(--secondary); }
 
 /* --- Index summary and navigation --- */
 .summary-container { text-align: center; margin-top: 20px; }
 .summary-box { margin-top:20px; }
-.summary-row { display:flex; gap:32px; justify-content:center; flex-wrap:wrap; }
+.summary-row {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  justify-content: center;
+}
 .summary-item { background:#fff; border-radius:12px; box-shadow:0 2px 8px #e0e7ef; padding:18px; cursor:pointer; transition:box-shadow .2s; min-width:220px; }
 .summary-item:hover { box-shadow:0 4px 16px #b6d0fa; }
 .summary-item.active { box-shadow:0 4px 18px #b6d0fa; }
 .summary-item.active .arrow { transform:rotate(90deg); }
-.summary-total-dygn { background:#2563eb; color:#fff; border-radius:10px; padding:14px 18px; margin-bottom:12px; box-shadow:0 2px 8px #b6d0fa; }
+.summary-total-dygn { background:var(--secondary); color:#fff; border-radius:10px; padding:14px 18px; margin-bottom:12px; box-shadow:0 2px 8px #b6d0fa; }
 .summary-main { font-size:1em; }
 .summary-shifts { display:none; margin-top:12px; }
 .shift-summary-mini { background:#f1f5fa; border-radius:8px; padding:6px 10px; margin-top:6px; font-size:0.95em; }
 
-.nav-buttons { display:flex; justify-content:center; gap:20px; margin-top:20px; flex-wrap:wrap; }
-.nav-button { background:#4f46e5; color:#fff; padding:12px 18px; text-decoration:none; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.1); font-weight:600; transition:background .2s; }
+.nav-buttons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+.nav-button { background:var(--primary); color:#fff; padding:12px 18px; text-decoration:none; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.1); font-weight:600; transition:background .2s; }
 .nav-button:hover { background:#4338ca; }
+
+/* Index layout */
+.main-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.main-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
 
 /* Extra info text */
 .guidance {
@@ -308,7 +346,7 @@ button:hover, .shift-btn:hover { background: #4338ca; }
 .shift-toggle { position:relative; font-weight:600; letter-spacing:0.5px; box-shadow:0 2px 8px #e0e7ef, 0 0 0 2px #3b82f6 inset; }
 .shift-toggle .shift-arrow { font-size:1em; margin-right:6px; transition:transform 0.2s; }
 .shift-toggle.active-shift .shift-arrow { transform:rotate(90deg); }
-.shift-toggle::after { content:'Klicka för att visa'; display:block; font-size:0.85em; color:#2563eb; margin-top:2px; font-weight:400; letter-spacing:0; }
+.shift-toggle::after { content:'Klicka för att visa'; display:block; font-size:0.85em; color:var(--secondary); margin-top:2px; font-weight:400; letter-spacing:0; }
 .shift-wrapper { background:#f4f7fb; border-radius:12px; box-shadow:0 2px 8px rgba(0,0,0,0.05); margin-bottom:32px; padding:24px; }
 .shift-summary { background:#e0e7ef; border-radius:8px; margin:0 0 18px 0; padding:16px 20px; font-size:1.08em; }
 .orders-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); gap:18px; margin-top:18px; }
@@ -327,6 +365,23 @@ button:hover, .shift-btn:hover { background: #4338ca; }
 .order-summary{display:flex;align-items:center;justify-content:space-between;cursor:pointer;gap:10px;}
 .calc-result{margin-top:6px;background:#f9fafb;border-radius:6px;padding:8px;}
 .analysis-box{background:#fef2f2;border-left:4px solid #ef4444;padding:10px 12px;border-radius:8px;color:#991b1b;margin-bottom:12px;}
+.manual-stop{
+  background:#fee2e2;
+  color:#b91c1c;
+  border:1px solid #fecaca;
+  border-radius:6px;
+  padding:4px 6px;
+  font-size:0.85em;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+}
+.manual-stop button{
+  background:none;
+  border:none;
+  color:#b91c1c;
+  cursor:pointer;
+}
 @media (max-width:700px){
   .shift-bar { flex-direction: column; gap:10px; }
   .shift-wrapper { padding:10px 4px; }


### PR DESCRIPTION
## Summary
- allow machine pages to reorder orders via drag and drop
- add manual stop planning with start/end prompts
- display stops in schedule

## Testing
- `npm test`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68478a488534832883971f868150aa70