### PR TITLE
Fix shift config global and enable planner modules

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -62,18 +62,19 @@
         </div>
       </div>
       <div id="shiftsOverview" class="shifts-overview"></div>
-    </div>    <script src="src/config/machine-speeds.js"></script>
-    <script src="src/config/shifts.js"></script>
-    <script src="src/config/transfer-config.js"></script>
-    <script src="src/utils/time-utils.js"></script>
-    <script src="src/utils/speed-calculator.js"></script>
-    <script src="src/utils/roll-estimator.js"></script>
-    <script src="src/utils/production-calculator.js"></script>
-    <script src="src/utils/scheduling.js"></script>
-    <script src="src/utils/transfer-utils.js"></script>
-    <script src="src/utils/transfer-ui.js"></script>
-    <script src="production.js"></script>
-    <script src="planner.js"></script>
+    </div>
+    <script type="module" src="src/config/machine-speeds.js"></script>
+    <script type="module" src="src/config/shifts.js"></script>
+    <script type="module" src="src/config/transfer-config.js"></script>
+    <script type="module" src="src/utils/time-utils.js"></script>
+    <script type="module" src="src/utils/speed-calculator.js"></script>
+    <script type="module" src="src/utils/roll-estimator.js"></script>
+    <script type="module" src="src/utils/production-calculator.js"></script>
+    <script type="module" src="src/utils/scheduling.js"></script>
+    <script type="module" src="src/utils/transfer-utils.js"></script>
+    <script type="module" src="src/utils/transfer-ui.js"></script>
+    <script type="module" src="production.js"></script>
+    <script type="module" src="planner-refactored.js"></script>
     <script>
       // --- Dynamisk rendering av skift, summering och analys ---
       // Färger hämtas nu från CSS-variabler för att matcha index.html och övriga sidor

--- a/src/config/shifts.js
+++ b/src/config/shifts.js
@@ -28,6 +28,23 @@ export const SHIFT_ORDER = ["FM", "EM", "Natt"];
 
 export const SHIFT_COLORS = {
   FM: "#2563eb",
-  EM: "#60a5fa", 
+  EM: "#60a5fa",
   Natt: "#fbbf24"
 };
+
+// Derived constant for compatibility with legacy scripts
+export const SHIFT_TIMES = {
+  FM: { START: SHIFT_DEFINITIONS.FM.start, END: SHIFT_DEFINITIONS.FM.end },
+  EM: { START: SHIFT_DEFINITIONS.EM.start, END: SHIFT_DEFINITIONS.EM.end },
+  NATT: { START: SHIFT_DEFINITIONS.Natt.start, END: SHIFT_DEFINITIONS.Natt.end }
+};
+
+// Expose configuration on the window for non-module environments
+if (typeof window !== "undefined") {
+  window.ShiftsConfig = {
+    SHIFT_DEFINITIONS,
+    SHIFT_ORDER,
+    SHIFT_COLORS,
+    SHIFT_TIMES
+  };
+}


### PR DESCRIPTION
## Summary
- expose a `SHIFT_TIMES` constant and global `ShiftsConfig` in the shift config
- load planner scripts as ES modules and use `planner-refactored.js`

## Testing
- `npm run lint` *(fails: 559 errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9a0538788328b6e55bc135633c45